### PR TITLE
Cleanup interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Set all of these settings:
 
 - `PGP_NAME`: The name part of the user ID for for the bot's OpenPGP keypair
 - `PGP_EMAIL`: The email part of the user ID for for the bot's OpenPGP keypair. This should be the email address that users are expected to email.
+- `GPG_HOMEDIR`: The directory in which the bot's keyring will be stored (it will be created by the bot if it does not exist). This should be in a location that is writeable by the bot.
 - `IMAP_SERVER`: The IMAP server to connect to, e.g. `imap.gmail.com`
 - `IMAP_USERNAME`: The IMAP username
 - `IMAP_PASSWORD`: The IMAP password

--- a/bot_test.py
+++ b/bot_test.py
@@ -17,7 +17,6 @@ class BotTest(unittest.TestCase):
         self.gpg.import_keys(self.private_key)
         
         # set up tester
-        self.pgp_tester = bot.OpenPGPEmailParser(gpg=self.gpg)
         self.emails = {}
         for filename in ['encrypted_to_wrong_key', 'signed', 'unencrypted_thunderbird', 'encrypted_correctly']: 
             self.emails[filename] = email.message_from_string(open('test_emails/'+filename).read())
@@ -26,29 +25,33 @@ class BotTest(unittest.TestCase):
         pass
 
     def test_encrypted(self):
-        self.pgp_tester.set_new_email(self.emails['encrypted_to_wrong_key'])
-        self.assertTrue(self.pgp_tester.properties['encrypted'])
+        msg = bot.OpenPGPMessage(self.emails['encrypted_to_wrong_key'],
+                                 gpg=self.gpg)
+        self.assertTrue(msg.encrypted)
 
     def test_unencrypted(self):
-        self.pgp_tester.set_new_email(self.emails['unencrypted_thunderbird'])
-        self.assertFalse(self.pgp_tester.properties['encrypted'])
+        msg = bot.OpenPGPMessage(self.emails['unencrypted_thunderbird'],
+                                 gpg=self.gpg)
+        self.assertFalse(msg.encrypted)
 
     def test_signed(self):
-        self.pgp_tester.set_new_email(self.emails['signed'])
-        self.assertTrue(self.pgp_tester.properties['signed'])
+        msg = bot.OpenPGPMessage(self.emails['signed'],
+                                 gpg=self.gpg)
+        self.assertTrue(msg.signed)
         
     def test_unsigned(self):
-        self.pgp_tester.set_new_email(self.emails['signed'])
-        self.assertTrue(self.pgp_tester.properties['signed'])
+        # todo finish
+        pass
 
     def test_encrypted_wrong_key(self):
         # tododta fill this out
         pass
 
     def test_encrypted_correct_key(self):
-        self.pgp_tester.set_new_email(self.emails['encrypted_correctly'])
         result_text = "encrypted text"
-        self.assertEquals(result_text, self.pgp_tester.decrypted_text.split("quoted-printable")[1].strip())
+        msg = bot.OpenPGPMessage(self.emails['encrypted_correctly'],
+                                 gpg=self.gpg)
+        self.assertEquals(result_text, msg.decrypted_text.split("quoted-printable")[1].strip())
 
 
 if __name__ == '__main__':

--- a/config_template.py
+++ b/config_template.py
@@ -2,6 +2,9 @@
 PGP_NAME = "OpenPGP Bot"
 PGP_EMAIL = ""
 
+# Directory where the bot's GPG keyring is stored
+GPG_HOMEDIR = "bot_keyring"
+
 # you can either use a maildir or you can use IMAP
 # set MAILDIR to False to use IMAP, otherwise set it to a path
 MAILDIR = False


### PR DESCRIPTION
If the tests pass, feel free to merge this branch into master -- I noticed one test still needs to be re-implemented but that's OK. The refactoring looks great overall, but I haven't run or tested the code. Inheriting from Message is a great idea, and simplifies the code. Nice job doing away with the unnecessary 'properties' variable too, and identifying the GPG_HOMEDIR config value.

A couple of comments for looking ahead, not things that need to be changed in this code:

(1) I don't think we should be so cavalier in creating a new key for the bot. Creating a new key should be doable, for sure, but maybe with a command-line flag that has to be explicitly passed in or something like that. I think the normal behavior should be failure if a key doesn't exist. In fact, you should be able to pass in a fingerprint and the code should fail if a private key cannot be found with this fp. This is because we are going to widely publish some key and say "encrypt this to key 13374A1BEEF..." We want to be sure to fail if we can't find that key for some reason, as opposed to generating a new one.

(2) There should be a graceful failure if OpenPGPMessage doesn't have a keyring it can read, or can't decrypt a message.

(3) Much more minor stylistic comment. Mental note to move the check_bot_keypair function call into main, and break out the logic in main into more functions if desired, assuming no objections? Just prefer keeping this orderly, especially if we add argparse code, but very minor and I don't care too much.
