### PR TITLE
Unsubscribes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,19 @@ virtualenv:
 
 To avoid exploitation as an automated spam cannon, cryptobot can optionally
 maintain a database of unsubscribers. It requires one additional setup step.
-After installing requirements, uncomment the DATABASE_URL in config.py.
+After installing requirements, uncomment the DATABASE_URL in config.py, and
+run
 
 ```
 ./unsubscribe.py --setup
+```
+
+This will create the necessary database tables and generate a random salt for
+hashing email addresses. Once that's done, you can run the included Flask app
+to serve a simple unsubscribe form.
+
+```
+./app.py    # http://localhost:5000/unsubscribe
 ```
 
 For simplicity, you can use an sqlite database, which is created as a normal

--- a/README.md
+++ b/README.md
@@ -47,8 +47,16 @@ run
 ```
 
 This will create the necessary database tables and generate a random salt for
-hashing email addresses. Once that's done, you can run the included Flask app
-to serve a simple unsubscribe form.
+hashing email addresses. Once that's done, you can add emails to the database
+by running
+
+```
+./unsubscribe.py --add foo@example.com
+
+```
+
+Alternatively you can run the included Flask app to serve a simple unsubscribe
+form for people to unsubscribe themselves.
 
 ```
 ./app.py    # http://localhost:5000/unsubscribe

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Set all of these settings:
 - `SMTP_SERVER`: The SMTP server to connect to, e.g. `smtp.gmail.com`
 - `SMTP_USERNAME`: The SMTP username
 - `SMTP_PASSWORD`: The SMTP password
+- `DATABASE_URL`: (Optional) URL for the unsubscribe database
+
 
 This is a Python project with some external dependencies. We recommend using
 virtualenv:
@@ -31,6 +33,34 @@ virtualenv:
     (env) $ ./bot.py
     # when you're done
     (env) $ deactivate
+
+
+## Unsubscribes
+
+To avoid exploitation as an automated spam cannon, cryptobot can optionally
+maintain a database of unsubscribers. It requires one additional setup step.
+After installing requirements, uncomment the DATABASE_URL in config.py.
+
+```
+./unsubscribe.py --setup
+```
+
+For simplicity, you can use an sqlite database, which is created as a normal
+file in the directory of your choosing, and does not incur any extra
+dependencies. However, for better concurrency handling, you may want to install
+and use postgresql, which will require the psycopg2 python module along with
+some additional system configuration:
+
+```
+sudo apt-get install postgresql
+sudo -u postgres createuser -P -s -e cryptobot
+createdb cryptobot -O cryptobot
+sudo apt-get install postgresql-server-dev-9.1
+. env/bin/activate
+pip install psycopg
+deactivate
+```
+
 
 ## Dev Notes
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Set all of these settings:
 - `SMTP_SERVER`: The SMTP server to connect to, e.g. `smtp.gmail.com`
 - `SMTP_USERNAME`: The SMTP username
 - `SMTP_PASSWORD`: The SMTP password
-- `DATABASE_URL`: (Optional) URL for the unsubscribe database
+- `DATABASE_URL`: URL for the unsubscribe database
 
 
 This is a Python project with some external dependencies. We recommend using

--- a/app.py
+++ b/app.py
@@ -19,5 +19,5 @@ if __name__ == '__main__':
       db = unsub.getDatabase(config.DATABASE_URL)
       if db is None:
         print "Failed to connect to unsubscribe database url '%s'" % config.DATABASE_URL
-        exit(1)
+        sys.exit(1)
       app.run()

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import config
 import unsubscribe as unsub
 from flask import Flask, render_template, request

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ db = None
 def unsubscribe():
       if request.method == 'POST':
         email_address = request.form['email']
+        db = unsub.getDatabase(config.DATABASE_URL)
         db.add(email_address)
         return "%s unsubscribed!" % email_address
       else:

--- a/app.py
+++ b/app.py
@@ -10,8 +10,7 @@ db = None
 def unsubscribe():
       if request.method == 'POST':
         email_address = request.form['email']
-        if not db.find(email_address):
-          db.add(email_address)
+        db.add(email_address)
         return "%s unsubscribed!" % email_address
       else:
         return render_template('unsubscribe.html')

--- a/app.py
+++ b/app.py
@@ -1,0 +1,22 @@
+import config
+import unsubscribe as unsub
+from flask import Flask, render_template, request
+app = Flask(__name__)
+db = None
+
+@app.route('/unsubscribe', methods=['GET', 'POST'])
+def unsubscribe():
+      if request.method == 'POST':
+        email_address = request.form['email']
+        if not db.find(email_address):
+          db.add(email_address)
+        return "%s unsubscribed!" % email_address
+      else:
+        return render_template('unsubscribe.html')
+
+if __name__ == '__main__':
+      db = unsub.getDatabase(config.DATABASE_URL)
+      if db is None:
+        print "Failed to connect to unsubscribe database url '%s'" % config.DATABASE_URL
+        exit(1)
+      app.run()

--- a/bot.py
+++ b/bot.py
@@ -725,8 +725,10 @@ def main(fingerprint):
     messages = fetcher.get_all_mail()
     logging.info("Found {0} messages".format(len(messages)))
 
-
     db = unsubscribe.getDatabase(config.DATABASE_URL)
+    if db is None:
+      print "Failed to connect to unsubscribe database url '%s'" % config.DATABASE_URL
+      sys.exit(1)
 
     for message in messages:
         if not db.find(message.sender_address()):

--- a/bot.py
+++ b/bot.py
@@ -726,7 +726,7 @@ def main(fingerprint):
     logging.info("Found {0} messages".format(len(messages)))
 
 
-    db = unsubscribe.Database(config.DATABASE_URL)
+    db = unsubscribe.getDatabase(config.DATABASE_URL)
 
     for message in messages:
         if not db.find(message.sender_address()):

--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,7 @@ import jinja2
 import rfc822
 import quopri
 import logging
+import unsubscribe
 
 PGP_ARMOR_HEADER_MESSAGE   = "-----BEGIN PGP MESSAGE-----"
 PGP_ARMOR_HEADER_SIGNATURE = "-----BEGIN PGP SIGNATURE-----"
@@ -723,9 +724,14 @@ def main(fingerprint):
     fetcher = EmailFetcher(use_maildir=config.USE_MAILDIR)
     messages = fetcher.get_all_mail()
     logging.info("Found {0} messages".format(len(messages)))
+
+
+    db = unsubscribe.Database(config.DATABASE_URL)
+
     for message in messages:
-        # respond to the email
-        EmailSender(message, template_env, fingerprint)
+        if not db.find(message.sender_address()):
+          # respond to the email
+          EmailSender(message, template_env, fingerprint)
 
         # delete the email
         # (note: by default Gmail ignores the IMAP standard and archives email instead of deleting it

--- a/bot.py
+++ b/bot.py
@@ -731,7 +731,7 @@ def main(fingerprint):
       sys.exit(1)
 
     for message in messages:
-        if not db.find(message.sender_address()):
+        if not db.find(message.sender_address):
           # respond to the email
           EmailSender(message, template_env, fingerprint)
 

--- a/config_template.py
+++ b/config_template.py
@@ -20,3 +20,8 @@ SMTP_SERVER = ""
 SMTP_USERNAME = ""
 SMTP_PASSWORD = ""
 
+# URL for the unsubscribe database
+# setup:
+#  $ createdb cryptobot      # creates a postgres database
+#  $ ./unsubscribe --create  # creates tables and random salt in that database
+DATABASE_URL = 'postgresql://username:password@localhost/cryptobot'

--- a/config_template.py
+++ b/config_template.py
@@ -21,7 +21,5 @@ SMTP_USERNAME = ""
 SMTP_PASSWORD = ""
 
 # URL for the unsubscribe database
-# setup:
-#  $ createdb cryptobot      # creates a postgres database
-#  $ ./unsubscribe --setup   # creates tables and random salt in that database
-DATABASE_URL = 'postgresql://username:password@localhost/cryptobot'
+# To set up the database run `./unsubscribe --setup`
+DATABASE_URL = 'sqlite:///%s/cryptobot.db' % GPG_HOMEDIR

--- a/config_template.py
+++ b/config_template.py
@@ -23,5 +23,5 @@ SMTP_PASSWORD = ""
 # URL for the unsubscribe database
 # setup:
 #  $ createdb cryptobot      # creates a postgres database
-#  $ ./unsubscribe --create  # creates tables and random salt in that database
+#  $ ./unsubscribe --setup   # creates tables and random salt in that database
 DATABASE_URL = 'postgresql://username:password@localhost/cryptobot'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ distribute==0.6.34
 psutil==1.0.1
 wsgiref==0.1.2
 Jinja2==2.6
+SQLAlchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ distribute==0.6.34
 psutil==1.0.1
 wsgiref==0.1.2
 Jinja2==2.6
-psycopg2
 SQLAlchemy
 passlib
 flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Jinja2==2.6
 psycopg2
 SQLAlchemy
 passlib
+flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ distribute==0.6.34
 psutil==1.0.1
 wsgiref==0.1.2
 Jinja2==2.6
+psycopg2
 SQLAlchemy
+passlib

--- a/templates/email_template.html
+++ b/templates/email_template.html
@@ -51,6 +51,9 @@
         <tr><td style="color:#000000; font-size:0.8em; padding-right:10px;">pubkey_fingerprint</td><td style="color:#000000; font-size:0.8em;">{{pubkey_fingerprint}}</td></tr>
       </table>
       #}
+      <p> To permanently block Cryptobot emails visit
+        <a href="https://www.cryptobot.org/unsubscribe">the unsubscribe page</a>.
+      </p>
     </div>
   </body>
 </html>

--- a/templates/email_template.txt
+++ b/templates/email_template.txt
@@ -51,3 +51,8 @@ pubkey_included: {{pubkey_included}}
 pubkey_included_wrong: {{pubkey_included_wrong}}
 pubkey_fingerprint: {{pubkey_fingerprint}}
 #}
+
+------------------------------------------------------------------
+To permanently block Cryptobot emails visit the unsubscribe page:
+https://www.cryptobot.org/unsubscribe
+------------------------------------------------------------------

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <p>Greetings human! If cryptobot had emotions, it would be sad to see you go.<p>
+    <form method="post">
+      <label name="email">Email:</label>
+      <input type="text" name="email">
+      <input type="submit" value="Unsubscribe">
+    </form>
+  </body>
+</html>

--- a/test.py
+++ b/test.py
@@ -3,10 +3,14 @@
 import os
 import unittest
 import bot
+import unsubscribe
 import email
 import random
 import sys
 import jinja2
+
+from sqlalchemy.ext.declarative import declarative_base
+SQLAlchemyBase = declarative_base()
 
 class GnuPGTest(unittest.TestCase):
     def setUp(self):
@@ -196,6 +200,17 @@ class EmailSenderTest(unittest.TestCase):
                                  gpg=self.gpg)
         bot.EmailSender(msg, self.env, fingerprint= '0D4AF6E8D289BDE46594D41255BB44BA0D3E5387',  sender=self.get_mock_sender())
         self.assertTrue('justtesting@example.com' in self.reply_to)
+
+class UnsubscribeTest(unittest.TestCase):
+    def setUp(self):
+      self.db = unsubscribe.getDatabase('sqlite:///test/test.db', setup=True)
+
+    def tearDown(self):
+      unsubscribe.BlockedEmail.metadata.drop_all(self.db.engine)
+
+    def test_add(self):
+      self.db.add('test@example.com')
+      self.assertTrue(self.db.find('test@example.com') is not None)
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -9,9 +9,6 @@ import random
 import sys
 import jinja2
 
-from sqlalchemy.ext.declarative import declarative_base
-SQLAlchemyBase = declarative_base()
-
 class GnuPGTest(unittest.TestCase):
     def setUp(self):
         # test keys

--- a/test.py
+++ b/test.py
@@ -203,7 +203,7 @@ class EmailSenderTest(unittest.TestCase):
 
 class UnsubscribeTest(unittest.TestCase):
     def setUp(self):
-      self.db = unsubscribe.getDatabase('sqlite:///test/test.db', setup=True)
+      self.db = unsubscribe.getDatabase('sqlite:///test/homedir/test.db', setup=True)
 
     def tearDown(self):
       unsubscribe.BlockedEmail.metadata.drop_all(self.db.engine)

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -73,11 +73,11 @@ def getDatabase(url, setup=False, debug=False):
     try:
       db = Database(url, setup, debug)
     except OperationalError as e:
-      print e
       print "Check that the database exists and DATABASE_URL is configured correctly"
+      raise e
     except ProgrammingError as e:
-      print e
       print "Did you forget to run `./unsubscribe --setup` ?"
+      raise e
     return db
 
 if __name__ == "__main__":
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     db = getDatabase(DATABASE_URL, args.setupDB, args.debugDB)
 
     if db is None:
-      exit(1)
+      sys.exit(1)
 
     if args.email:
       if not db.find(args.email):

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -68,10 +68,6 @@ class Database():
     self.session.commit()
 
 
-def block_email(address, db):
-    if not db.find(address):
-      db.add(address)
-
 def getDatabase(url, setup=False, debug=False):
     db = None
     try:
@@ -98,6 +94,9 @@ if __name__ == "__main__":
     db = getDatabase(DATABASE_URL, args.setupDB, args.debugDB)
 
     if args.email:
-      block_email(email)
+      if not db.find(args.email):
+        db.add(args.email)
+      else:
+        print "That email is already unsubscribed"
 
     print db.session.query(BlockedEmail).all()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -98,5 +98,3 @@ if __name__ == "__main__":
         db.add(args.email)
       else:
         print "That email is already unsubscribed"
-
-    print db.session.query(BlockedEmail).all()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import string
 from passlib.hash import sha1_crypt
 from random import SystemRandom
 from sqlalchemy import MetaData, Table, Column, String, ForeignKey, create_engine, Integer

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -75,11 +75,9 @@ def getDatabase(url, setup=False, debug=False):
     except OperationalError as e:
       print e
       print "Check that the database exists and DATABASE_URL is configured correctly"
-      exit(1)
     except ProgrammingError as e:
       print e
       print "Did you forget to run `./unsubscribe --setup` ?"
-      exit(1)
     return db
 
 if __name__ == "__main__":
@@ -92,6 +90,9 @@ if __name__ == "__main__":
 
     from config import DATABASE_URL
     db = getDatabase(DATABASE_URL, args.setupDB, args.debugDB)
+
+    if db is None:
+      exit(1)
 
     if args.email:
       if not db.find(args.email):

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -73,6 +73,7 @@ def block_email(address, db):
       db.add(address)
 
 def getDatabase(url, setupDB=False):
+    db = None
     try:
       db = Database(url, setupDB)
     except OperationalError as e:
@@ -83,6 +84,7 @@ def getDatabase(url, setupDB=False):
       print e
       print "Did you forget to run `./unsubscribe --setup` ?"
       exit(1)
+    return db
 
 if __name__ == "__main__":
     import argparse

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -60,7 +60,7 @@ class Database():
     return sha1_crypt.encrypt(email_address, rounds=self.hash_params.rounds, salt=self.hash_params.salt)
 
   def find(self, email_address):
-    return self.session.query(BlockedEmail).filter_by(hashed_address=self.hash(email_address)).first()
+    return self.find_hashed(self.hash(email_address))
 
   def find_hashed(self, hashed_address):
     return self.session.query(BlockedEmail).filter_by(hashed_address=hashed_address).first()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -41,6 +41,9 @@ class Database():
     self.hash_params = self.session.query(Hash).first()
 
   def setup(self):
+    # todo: avoid setting up if tables already exsit and/or have data?
+    # as long as we only read the first hash in __init__, we should be
+    # ok calling this function again, but it will add extra hash records
     SQLAlchemyBase.metadata.create_all(self.engine)
     self.session = sessionmaker(self.engine)()
     hash_count = self.session.query(Hash).count()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -1,38 +1,87 @@
 #!/usr/bin/env python
 
-# $ createdb dbname
-
-from passlib.hash import sha256_crypt
-
+from passlib.hash import sha1_crypt
+from random import SystemRandom
 from sqlalchemy import MetaData, Table, Column, String, ForeignKey, create_engine
 from sqlalchemy.orm import mapper, relationship, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
-Base = declarative_base()
-session = None
+SQLAlchemyBase = declarative_base()
 
-class BlockedEmail(Base):
+class BlockedEmail(SQLAlchemyBase):
   __tablename__ = 'unsubscribe'
-  address = Column(String, primary_key=True)
+  hashed_address = Column(String, primary_key=True)
 
-  def __init__(self, address):
-    self.address = address;
+  def __init__(self, hashed_address):
+    self.hashed_address = hashed_address
+
+class Hash(SQLAlchemyBase):
+  __tablename__ = 'hash'
+  uid = Column(Integer, primary_key=true)
+  salt = Column(String)
+  rounds = Column(Integer)
+  name = Column(String) # just for reference
+
+  def __init__(self, salt, rounds, name='SHA1'):
+    self.salt = salt
+    self.rounds = rounds
+    self.name = name
 
 
-def createDB(engine):
-    Base.metadata.create_all(engine)
+class Database():
+  def __init__(self, url, create=False):
+    self.engine = create_engine(url, echo=True)
 
-def block_email(address):
-    hashed_address = sha256_crypt.encrypt(address, rounds=12345, salt='aconstantsalt')
-    if not session.query(BlockedEmail).filter_by(address=hashed_address).first():
-      block = BlockedEmail(hashed_address)
-      session.add(block)
-      session.commit()
+    if create:
+      self.create()
+      self.session = sessionmaker(self.engine)()
+      self.create_hash_params() # requires self.session
+    else:
+      self.session = sessionmaker(engine)()
+
+    self.hash_params = self.session.query(Hash).last()
+
+  def create(self):
+    SQLAlchemyBase.metadata.create_all(self.engine)
+
+
+  def random_string(self):
+    return ''.join(SystemRandom.choice(string.ascii_uppercase + string.digits) for x in range(32))
+
+  def create_hash_params(self):
+    salt = self.random_string()
+    rounds = 12345
+    hash_params = Hash(salt, rounds)
+    self.session.add(hash_params)
+    self.session.commit()
+
+  def hash(self, email_address):
+    # todo: 1. support for other hash algorithms based on hash_params.name
+    #       2. hash using all the configs, iteratively. this way if the
+    #          salt is ever compromised, just add a new salt on top.
+    return sha1_crypt.encrypt(address, rounds=self.hash_params.rounds, salt=self.hash_params.salt)
+
+  def find(self, email_address):
+    self.session.query(BlockedEmail).filter_by(hashed_address=self.hash(email_address)).first()
+
+  def add(self, email_address):
+    block = BlockedEmail(self.hash(email_address))
+    self.session.add(block)
+    self.session.commit()
+
+
+def block_email(address, db):
+    if not db.find(address):
+      db.add(address)
 
 if __name__ == "__main__":
-    engine = create_engine('postgresql://lilia:password@localhost/test', echo=True)
-    createDB(engine)
-    session = sessionmaker(engine)()
+    import argparse
+    parser = argparse.ArgumentParser(description="Cryptobot unsubscribe parser")
+    parser.add_argument('--create', dest='createDB', action='store_true', default=False)
+    parser.add_argument('--add', dest='email', action='store')
 
-    block_email("foo@bar.com")
+    db = Database(config.DATABASE_URL, createDB)
 
-    print session.query(BlockedEmail).all()
+    if email:
+      block_email(email)
+
+    print db.session.query(BlockedEmail).all()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -62,11 +62,15 @@ class Database():
   def find(self, email_address):
     return self.session.query(BlockedEmail).filter_by(hashed_address=self.hash(email_address)).first()
 
-  def add(self, email_address):
-    block = BlockedEmail(self.hash(email_address))
-    self.session.add(block)
-    self.session.commit()
+  def find_hashed(self, hashed_address):
+    return self.session.query(BlockedEmail).filter_by(hashed_address=hashed_address).first()
 
+  def add(self, email_address):
+    hashed_addres = self.hash(email_address)
+    if !self.find_hashed(hashed_address):
+      block = BlockedEmail(hashed_address)
+      self.session.add(block)
+      self.session.commit()
 
 def getDatabase(url, setup=False, debug=False):
     db = None

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -2,7 +2,7 @@
 
 from passlib.hash import sha1_crypt
 from random import SystemRandom
-from sqlalchemy import MetaData, Table, Column, String, ForeignKey, create_engine
+from sqlalchemy import MetaData, Table, Column, String, ForeignKey, create_engine, Integer
 from sqlalchemy.orm import mapper, relationship, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 SQLAlchemyBase = declarative_base()
@@ -16,7 +16,7 @@ class BlockedEmail(SQLAlchemyBase):
 
 class Hash(SQLAlchemyBase):
   __tablename__ = 'hash'
-  uid = Column(Integer, primary_key=true)
+  uid = Column(Integer, primary_key=True)
   salt = Column(String)
   rounds = Column(Integer)
   name = Column(String) # just for reference

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -66,8 +66,8 @@ class Database():
     return self.session.query(BlockedEmail).filter_by(hashed_address=hashed_address).first()
 
   def add(self, email_address):
-    hashed_addres = self.hash(email_address)
-    if !self.find_hashed(hashed_address):
+    hashed_address = self.hash(email_address)
+    if not self.find_hashed(hashed_address):
       block = BlockedEmail(hashed_address)
       self.session.add(block)
       self.session.commit()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -57,7 +57,7 @@ class Database():
 
   def hash(self, email_address):
     # todo: 1. support for other hash algorithms based on hash_params.name
-    return sha1_crypt.encrypt(address, rounds=self.hash_params.rounds, salt=self.hash_params.salt)
+    return sha1_crypt.encrypt(email_address, rounds=self.hash_params.rounds, salt=self.hash_params.salt)
 
   def find(self, email_address):
     self.session.query(BlockedEmail).filter_by(hashed_address=self.hash(email_address)).first()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -60,7 +60,7 @@ class Database():
     return sha1_crypt.encrypt(email_address, rounds=self.hash_params.rounds, salt=self.hash_params.salt)
 
   def find(self, email_address):
-    self.session.query(BlockedEmail).filter_by(hashed_address=self.hash(email_address)).first()
+    return self.session.query(BlockedEmail).filter_by(hashed_address=self.hash(email_address)).first()
 
   def add(self, email_address):
     block = BlockedEmail(self.hash(email_address))

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -74,6 +74,7 @@ def getDatabase(url, create=False):
       db = Database(url, create)
     except OperationalError as e:
       print e
+      print "Check that the database exists and DATABASE_URL is configured correctly"
       exit(1)
 
 if __name__ == "__main__":

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -46,15 +46,14 @@ class Database():
     # ok calling this function again, but it will add extra hash records
     SQLAlchemyBase.metadata.create_all(self.engine)
     self.session = sessionmaker(self.engine)()
-    hash_count = self.session.query(Hash).count()
     salt = self.random_string()
     rounds = 12345
-    hash_params = Hash(hash_count + 1, salt, rounds)
+    hash_params = Hash(salt, rounds)
     self.session.add(hash_params)
     self.session.commit()
 
   def random_string(self):
-    return ''.join(SystemRandom.choice(string.ascii_uppercase + string.digits) for x in range(32))
+    return ''.join(SystemRandom().choice(string.ascii_uppercase + string.digits) for x in range(32))
 
   def hash(self, email_address):
     # todo: 1. support for other hash algorithms based on hash_params.name

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -30,8 +30,8 @@ class Hash(SQLAlchemyBase):
 
 
 class Database():
-  def __init__(self, url, setup=False):
-    self.engine = create_engine(url, echo=True)
+  def __init__(self, url, setup=False, debug=False):
+    self.engine = create_engine(url, echo=debug)
 
     if setup:
       self.setup()
@@ -72,10 +72,10 @@ def block_email(address, db):
     if not db.find(address):
       db.add(address)
 
-def getDatabase(url, setupDB=False):
+def getDatabase(url, setup=False, debug=False):
     db = None
     try:
-      db = Database(url, setupDB)
+      db = Database(url, setup, debug)
     except OperationalError as e:
       print e
       print "Check that the database exists and DATABASE_URL is configured correctly"
@@ -90,11 +90,12 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Cryptobot unsubscribe parser")
     parser.add_argument('--setup', dest='setupDB', action='store_true', default=False)
+    parser.add_argument('--debug', dest='debugDB', action='store_true', default=False)
     parser.add_argument('--add', dest='email', action='store')
     args = parser.parse_args()
 
     from config import DATABASE_URL
-    db = getDatabase(DATABASE_URL, args.setupDB)
+    db = getDatabase(DATABASE_URL, args.setupDB, args.debugDB)
 
     if args.email:
       block_email(email)

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -5,6 +5,7 @@ from random import SystemRandom
 from sqlalchemy import MetaData, Table, Column, String, ForeignKey, create_engine, Integer
 from sqlalchemy.orm import mapper, relationship, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.exc import OperationalError
 SQLAlchemyBase = declarative_base()
 
 class BlockedEmail(SQLAlchemyBase):
@@ -73,15 +74,24 @@ def block_email(address, db):
     if not db.find(address):
       db.add(address)
 
+def getDatabase(url, create=False):
+    try:
+      db = Database(url, create)
+    except OperationalError as e:
+      print e
+      exit(1)
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Cryptobot unsubscribe parser")
     parser.add_argument('--create', dest='createDB', action='store_true', default=False)
     parser.add_argument('--add', dest='email', action='store')
+    args = parser.parse_args()
 
-    db = Database(config.DATABASE_URL, createDB)
+    from config import DATABASE_URL
+    db = getDatabase(DATABASE_URL, args.createDB)
 
-    if email:
+    if args.email:
       block_email(email)
 
     print db.session.query(BlockedEmail).all()

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# $ createdb dbname
+
+from passlib.hash import sha256_crypt
+
+from sqlalchemy import MetaData, Table, Column, String, ForeignKey, create_engine
+from sqlalchemy.orm import mapper, relationship, sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+Base = declarative_base()
+session = None
+
+class BlockedEmail(Base):
+  __tablename__ = 'unsubscribe'
+  address = Column(String, primary_key=True)
+
+  def __init__(self, address):
+    self.address = address;
+
+
+def createDB(engine):
+    Base.metadata.create_all(engine)
+
+def block_email(address):
+    hashed_address = sha256_crypt.encrypt(address, rounds=12345, salt='aconstantsalt')
+    if not session.query(BlockedEmail).filter_by(address=hashed_address).first():
+      block = BlockedEmail(hashed_address)
+      session.add(block)
+      session.commit()
+
+if __name__ == "__main__":
+    engine = create_engine('postgresql://lilia:password@localhost/test', echo=True)
+    createDB(engine)
+    session = sessionmaker(engine)()
+
+    block_email("foo@bar.com")
+
+    print session.query(BlockedEmail).all()


### PR DESCRIPTION
This branch implements a postgres-powered unsubscribe db using sqlalchemy and sha1 salted and hashed email addresses using passlib.

Anybody watching this project have some spare cycles for code review or just feedback on the general direction of this branch?

---

To setup unsubscribes, configure the DATABASE_URL, then run
$ createdb cryptobot
$ ./unsubscribe --setup

To unsubscribe an address
$ ./unsubscribe --add foo@example.com

To un-unsubscribe an address...(TODO!)

Unsubscribed emails are salted and hashed before storage. The salt is a
random string generated during database creation, then stored in the
database itself. This makes it harder for the operator to shoot
themselves in the foot, than (for instance) a param in a config file.
